### PR TITLE
added "mock" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 ## Features
 
-- **validate** - Validates a root RAML file against the specification.
-- **compile**  - Compiles a root RAML file into a valid OpenAPI 2.0 document.
+- **validate** - Validates a root RAML document against the specification.
+- **compile**  - Compiles a root RAML document into a valid OpenAPI 2.0 document.
 - **init**     - Initialize a basic RAML document based on user input.
+- **mock**     - Mocks a root RAML document.
 
 ## Installation
 
@@ -20,10 +21,11 @@ $ npm install -g raml-cli
 Usage: raml <command>
 
 Commands:
-  compile <file> [options]  Compiles a root RAML file into a valid OpenAPI 2.0
+  compile <file> [options]  Compiles a root RAML document into a valid OpenAPI 2.0
                             document.
   init [options]            Initialize a RAML document.
-  validate <file>           Validates a root RAML file against the RAML
+  mock <file> [options]     Mocks a root RAML document .
+  validate <file>           Validates a root RAML document against the RAML
                             specification.
 
 Options:
@@ -38,7 +40,7 @@ For more information go to https://github.com/raml-org/raml-cli
 
 ### `raml validate <file>`
 
-The command can be used for validating the syntax of a RAML file as follows:
+The command can be used for validating the syntax of a RAML document as follows:
 
 ```
 raml validate examples/simple.raml
@@ -55,7 +57,7 @@ otherwise it will fail with a message containing an explanation on the error.
 
 ### `raml compile <file> [options]`
 
-Compiles a root RAML file into a valid OpenAPI 2.0 document. It can be used as follows:
+Compiles a root RAML document into a valid OpenAPI 2.0 document. It can be used as follows:
 
 ```
 raml compile examples/simple.raml
@@ -111,3 +113,33 @@ This command is using [Handlebars](http://handlebarsjs.com/) under the hood to i
 Type: `String`
 
 File path of a custom Handlebars template.
+
+### `raml mock <file> [options]`
+
+Mocks a root RAML document. It can be used as follows:
+
+```
+raml mock examples/simple.raml
+```
+
+if it succeds you see something like the following:
+
+```
+Mock service running at http://localhost:8080
+```
+
+otherwise it will fail with a message containing an explanation on the error.
+
+#### Command options
+
+**-p, --port [value]**
+
+Type: `String`
+
+Port number to bind the proxy. Default: `8080`.
+
+**--cors [value]**
+
+Type: `boolean`
+
+Enable CORS with the API. Default: `false`.

--- a/examples/another.raml
+++ b/examples/another.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: issue
+version: v1
+
+/foo:
+  get:
+    responses:
+      200:
+        headers:
+         foo:
+           default: 'bar'
+           type: string

--- a/examples/simple.raml
+++ b/examples/simple.raml
@@ -1,2 +1,18 @@
 #%RAML 1.0
 title: Simple Example
+
+types:
+  Customer:
+    properties:
+      name:
+
+/customers:
+  get:
+    responses: 
+      200:
+        body: 
+          application/json:
+            type: Customer[]
+            example:
+              - name: Christian
+              - name: Antonio

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raml-cli",
   "description": "A handy command-line tool for RAML developers.",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "keywords": [
     "raml",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raml-cli",
   "description": "A handy command-line tool for RAML developers.",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "main": "dist/index.js",
   "keywords": [
     "raml",
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@types/node": "^8.0.17",
+    "@types/yargs": "^8.0.2",
     "tslint": "^5.5.0",
     "typescript": "^2.4.2"
   },
@@ -25,9 +26,13 @@
   },
   "dependencies": {
     "colorize": "^0.1.0",
+    "finalhandler": "^1.0.4",
     "handlebars": "^4.0.10",
+    "http": "0.0.0",
     "inquirer": "^3.2.1",
+    "morgan": "^1.8.2",
     "oas-raml-converter": "^0.2.7",
+    "raml-mock-service": "^1.0.0",
     "raml-1-parser": "^1.1.29",
     "yargs": "^8.0.2"
   }

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -3,7 +3,7 @@ import converter = require('oas-raml-converter')
 const cconsole = require('colorize').console
 
 exports.command = 'compile <file> [options]'
-exports.desc = 'Compiles a root RAML file into a valid OpenAPI 2.0 document.'
+exports.desc = 'Compiles a root RAML document into a valid OpenAPI 2.0 document.'
 exports.builder = {
   'output': {
     description: 'Compiled OpenAPI 2.0 document file path.',

--- a/src/commands/mock.ts
+++ b/src/commands/mock.ts
@@ -1,0 +1,78 @@
+/**
+ * This command handles requests to mock a specific API specification. Mocking
+ * means to generate a fake service based on the examples defined in the spec
+ * for any endpoint.
+ * 
+ * This command is using the raml-mock-service implementation underneath.
+ * 
+ * Github: https://github.com/raml-org/raml-mock-service
+ */
+
+const mock = require('raml-mock-service')
+const http = require('http')
+const finalhandler = require('finalhandler')
+const Router = require('osprey').Router
+const morgan = require('morgan')
+const fs = require('fs')
+
+const cconsole = require('colorize').console
+
+exports.command = 'mock <file> [options]'
+exports.desc = 'Mocks a root RAML document.'
+exports.builder = {
+  'port': {
+    description: 'Port number to bind the proxy.',
+    default: '8080',
+    nargs: 1,
+    requiresArg: true,
+    alias: 'p'
+  },
+  'cors': {
+    description: 'Enable CORS with the API',
+    boolean: true
+  }
+}
+
+exports.handler = function(argv) {
+  if (!fs.existsSync(argv.file)) {
+    cconsole.log('#red[File \'%s\' does not exist!]', argv.file)
+    process.exit(1)
+  }
+
+  mockService(argv.file, argv.port, argv.cors);
+}
+
+/**
+ * Call osprey-mocking-service to handle the input and generate a
+ * mock service for a given RAML file.
+ * 
+ * @param file contains the API specification to generate the mocking service
+ * @param port defines on which port the mocking service should run (default: 8080)
+ * @param cors enables CORS with the API (default: false)
+ */
+function mockService(file: string, port: number, cors: boolean): void {
+  var options = {
+    cors: !!cors
+  }
+  mock.loadFile(file, options)
+    .then(function (app) {
+      var router = new Router()
+
+      // Log API requests.
+      router.use(morgan('combined'))
+      router.use(app)
+
+      var server = http.createServer(function (req, res) {
+        router(req, res, finalhandler(req, res))
+      })
+
+      server.listen(port, function () {
+        console.log('Mock service running at http://localhost:' + server.address().port)
+      })
+    })
+    .catch(function (err) {
+      console.log(err && err.stack || err.message)
+      process.exit(1)
+    })
+}
+

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -5,7 +5,7 @@ import fs = require('fs')
 const cconsole = require('colorize').console
 
 exports.command = 'validate <file>'
-exports.desc = 'Validates a root RAML file against the RAML specification.'
+exports.desc = 'Validates a root RAML document against the RAML specification.'
 
 exports.handler = function(argv) {
   cconsole.log('Validating #blue[%s]...', argv.file)


### PR DESCRIPTION
This PR adds a new command "mock" to the palette which enables people to easily generate and run a mocking service based on their RAML.